### PR TITLE
Update Chrome prodversion from 91.0 to 133.0

### DIFF
--- a/crx-dl.py
+++ b/crx-dl.py
@@ -33,7 +33,7 @@ except:
 crx_base_url = 'https://clients2.google.com/service/update2/crx'
 crx_params = urlencode({
     'response': 'redirect',
-    'prodversion': '91.0',
+    'prodversion': '133.0',
     'acceptformat': 'crx2,crx3',
     'x': 'id=' + ext_id + '&uc'
 })


### PR DESCRIPTION
For Chrome version 91.0, the Google API stopped returning extension files, causing the script to fail. Using the current Chrome version (133.0) resolves this issue.